### PR TITLE
feat(core): add `omit` method

### DIFF
--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,0 +1,41 @@
+import { isArray } from "@halvaradop/ts-utility-types/validate"
+import { deepMerge } from "./deep.js"
+
+/**
+ * Omit properties from an object by key or keys of the first level of the object.
+ * If the deep flag is set to true, it will create a deep copy of the object without
+ * the omitted properties. The keys to be omitted are located in the first level of the object.
+ *
+ * @param {Record<string, unknown>} object - The object to omit properties.
+ * @param {string | string[]} exclude - The key or keys to omit from the object.
+ * @param {boolean} deep - if true returns a deep copy of the object otherwise a shallow copy.
+ * @returns {Omit<Obj, Keys & keyof Obj>} - The object without the omitted properties.
+ * @example
+ *
+ * const user = {
+ *   username: "john_doe",
+ *   password: "john123",
+ *   email: "john_doe@gmail.com"
+ * }
+ *
+ * // Expected: { username: "john_doe", email: "john_doe@gmail.com" }
+ * omit(user, "password")
+ *
+ * // Expected: { username: "john_doe", email: "john_doe@gmail.com" }
+ * omit(user, ["password"])
+ */
+export const omit = <Obj extends Record<string, unknown>, Keys extends keyof Obj | (keyof Obj)[]>(
+    object: Obj,
+    exclude: Keys,
+    deep: boolean = false,
+): Omit<Obj, Keys & string> => {
+    const keys = isArray(exclude) ? exclude : [exclude]
+    const omitted = Object.keys(object).reduce(
+        (previous, now) => ({
+            ...previous,
+            ...(keys.includes(now as Keys) ? {} : { [now]: object[now] }),
+        }),
+        {},
+    )
+    return deep ? deepMerge(omitted, {}) : omitted
+}

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -1,0 +1,118 @@
+import { describe, test } from "vitest"
+import { omit } from "../src/omit"
+
+describe("omit", () => {
+    const testCases = [
+        {
+            description: "should omit a single top-level property",
+            input: {
+                username: "john_doe",
+                password: "john123",
+            },
+            exclude: "password",
+            deep: false,
+            expected: {
+                username: "john_doe",
+            },
+        },
+        {
+            description: "should omit a single nested property without deep omit",
+            input: {
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+                phone: {
+                    home: "1234567890",
+                    work: "0987654321",
+                },
+            },
+            exclude: "phone",
+            deep: false,
+            expected: {
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+            },
+        },
+        {
+            description: "should omit a single nested property with deep omit",
+            input: {
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+                phone: {
+                    home: "1234567890",
+                    work: "0987654321",
+                },
+            },
+            exclude: "phone",
+            deep: true,
+            expected: {
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+            },
+        },
+        {
+            description: "should omit multiple top-level properties without deep omit",
+            input: {
+                firstname: "john",
+                lastname: "doe",
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+                phone: {
+                    home: "1234567890",
+                    work: "0987654321",
+                },
+            },
+            exclude: ["phone", "address"],
+            deep: false,
+            expected: {
+                firstname: "john",
+                lastname: "doe",
+                username: "john_doe",
+            },
+        },
+        {
+            description: "should omit multiple nested properties with deep omit",
+            input: {
+                firstname: "john",
+                lastname: "doe",
+                username: "john_doe",
+                address: {
+                    city: "New York",
+                    country: "USA",
+                },
+                phone: {
+                    home: "1234567890",
+                    work: "0987654321",
+                },
+            },
+            exclude: ["phone", "address"],
+            deep: true,
+            expected: {
+                firstname: "john",
+                lastname: "doe",
+                username: "john_doe",
+            },
+        },
+    ]
+
+    testCases.forEach(({ description, input, exclude, deep, expected }) => {
+        test.concurrent(description, ({ expect }) => {
+            const actual = omit(input, exclude as keyof typeof input, deep)
+            expect(actual).toEqual(expected)
+        })
+    })
+})


### PR DESCRIPTION

## Description

This pull request introduces a new function to the library. The function is called `omit`, which creates a new object including the properties at the first level of an object. The new object can be a shadow copy or a deep copy, depending on the value of the `deep` argument passed to the function. The default values is `false`, which creates a shadow copy. This function was added to address the issues mentioned in issues #8

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
