### PR TITLE
fix(types): correct return types in `omit` and `deepOmit` functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "email": "hernanvid123@gmail.com",
     "url": "https://github.com/halvaradop/obstackle/issues"
   },
-  "dependencies": {
-    "@halvaradop/ts-utility-types": "^0.18.0"
-  },
   "devDependencies": {
+    "@halvaradop/ts-utility-types": "^0.19.0",
     "@types/node": "^22.13.5",
     "prettier": "^3.5.1",
     "tsup": "^8.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,10 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@halvaradop/ts-utility-types':
-        specifier: ^0.18.0
-        version: 0.18.0
     devDependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@types/node':
         specifier: ^22.13.5
         version: 22.13.5
@@ -180,8 +179,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@halvaradop/ts-utility-types@0.18.0':
-    resolution: {integrity: sha512-cH6VbMQDYTkMSQ/7rCU+kxTy1W7Cr6fLwZTRurW3t7NnDFft5herISUn3W3C/w8ghoy0uwRrn32F2wsjSnWPqQ==}
+  '@halvaradop/ts-utility-types@0.19.0':
+    resolution: {integrity: sha512-F8Sf5XVK/JN9MPIu6oK+rgGLSbtddw+rWcvhPzo3hNq+Se7l6XR2JfZXnUOYtGpHwTjwVuLXjs4OUJkw2fKWMw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -890,7 +889,7 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@halvaradop/ts-utility-types@0.18.0': {}
+  '@halvaradop/ts-utility-types@0.19.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/src/deep.ts
+++ b/src/deep.ts
@@ -1,6 +1,7 @@
 import { isObject, isArray } from "@halvaradop/ts-utility-types/validate"
 import { isSimpleType } from "./utils.js"
 import { deepOmit } from "./omit.js"
+import type { Merge as DeepMerge } from "@halvaradop/ts-utility-types/objects"
 
 /**
  * Merges two objects in any depth recursively.
@@ -14,12 +15,12 @@ import { deepOmit } from "./omit.js"
  * // Expected: { a: 1, b: { c: 2, d: 3 }, c: 4 }
  * deepMerge({ a: 1, b: { c: 2 } }, { b: { d: 3 }, c: 4 })
  */
-export const deepMerge = <S extends Record<string, unknown>, T extends Record<string, unknown>>(
-    source: S,
-    target: T,
+export const deepMerge = <Source extends Record<string, unknown>, Target extends Record<string, unknown>>(
+    source: Source,
+    target: Target,
     priority: "source" | "target" | "object" = "source",
     nullish: boolean = false,
-) => {
+): DeepMerge<Source, Target> => {
     const clone: any = {}
     const priorityOne = priority === "source" ? source : target
     const priorityTwo = priority === "source" ? target : source

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -39,7 +39,7 @@ export const omit = <Obj extends Record<string, unknown>, Keys extends keyof Obj
         }),
         {},
     )
-    return deep ? deepMerge(omitted, {}) : (omitted as Omit<Obj, ArgumentKeys<Keys>>)
+    return deep ? (deepMerge(omitted, {}) as Omit<Obj, ArgumentKeys<Keys>>) : (omitted as Omit<Obj, ArgumentKeys<Keys>>)
 }
 
 /**

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,5 +1,6 @@
 import { isArray, isObject } from "@halvaradop/ts-utility-types/validate"
-import { DeepKeys } from "@halvaradop/ts-utility-types"
+import type { DeepKeys, DeepOmit, LiteralUnion } from "@halvaradop/ts-utility-types/objects"
+import type { ArgumentKeys } from "./types.js"
 import { deepMerge } from "./deep.js"
 
 /**
@@ -8,7 +9,7 @@ import { deepMerge } from "./deep.js"
  * the omitted properties. The keys to be omitted are located in the first level of the object.
  *
  * @param {Record<string, unknown>} object - The object to omit properties.
- * @param {string | string[]} exclude - The key or keys to omit from the object.
+ * @param {string | string[]} omit - The key or keys to omit from the object.
  * @param {boolean} deep - if true returns a deep copy of the object otherwise a shallow copy.
  * @returns {Omit<Obj, Keys & keyof Obj>} - The object without the omitted properties.
  * @example
@@ -29,7 +30,7 @@ export const omit = <Obj extends Record<string, unknown>, Keys extends keyof Obj
     object: Obj,
     omit: Keys,
     deep: boolean = false,
-): Omit<Obj, Keys & string> => {
+): Omit<Obj, ArgumentKeys<Keys>> => {
     const keys = isArray(omit) ? omit : [omit]
     const omitted = Object.keys(object).reduce(
         (previous, now) => ({
@@ -38,17 +39,20 @@ export const omit = <Obj extends Record<string, unknown>, Keys extends keyof Obj
         }),
         {},
     )
-    return deep ? deepMerge(omitted, {}) : omitted
+    return deep ? deepMerge(omitted, {}) : (omitted as Omit<Obj, ArgumentKeys<Keys>>)
 }
 
 /**
  * @internal
  */
-const internalDeepOmit = <Obj extends Record<string, unknown>, Keys extends DeepKeys<Obj> | DeepKeys<Obj>[]>(
+const internalDeepOmit = <
+    Obj extends Record<string, unknown>,
+    Keys extends LiteralUnion<DeepKeys<Obj> & string, string> | LiteralUnion<DeepKeys<Obj> & string, string>[],
+>(
     object: Obj,
     omit: Keys,
     path: string,
-) => {
+): DeepOmit<Obj, ArgumentKeys<Keys>> => {
     const omitKeys = isArray(omit) ? omit : [omit]
     const clone: any = {}
     for (const key in object) {
@@ -61,10 +65,14 @@ const internalDeepOmit = <Obj extends Record<string, unknown>, Keys extends Deep
             clone[key] = object[key]
         }
     }
-    return clone
+    return clone satisfies DeepOmit<Obj, ArgumentKeys<Keys>>
 }
 
 /**
+ * @unstable
+ * The returned type is not accurate. It should be fixed in the next release
+ * of @halvaradop/ts-utility-types
+ *
  * Omit properties from an object at any depth by the provided key or keys.
  * The keys to be omitted can be located at any depth within the object. The
  * keys provided should be concatenated with a dot to represent the path to
@@ -76,9 +84,12 @@ const internalDeepOmit = <Obj extends Record<string, unknown>, Keys extends Deep
  * @param {DeepKeys<object> | DeepKeys<object>[]} omit - The key or keys to omit from the object.
  * @returns {Omit<DeepKeys<Obj>, Keys & keyof Obj>} - The object without the omitted properties.
  */
-export const deepOmit = <Obj extends Record<string, unknown>, Keys extends DeepKeys<Obj> | DeepKeys<Obj>[]>(
+export const deepOmit = <
+    Obj extends Record<string, unknown>,
+    Keys extends LiteralUnion<DeepKeys<Obj> & string, string> | LiteralUnion<DeepKeys<Obj> & string, string>[],
+>(
     object: Obj,
     omit: Keys,
-): Omit<Obj, keyof Obj> => {
-    return internalDeepOmit(object, omit, "")
+): DeepOmit<Obj, ArgumentKeys<Keys, string>> => {
+    return internalDeepOmit(object, omit, "") as DeepOmit<Obj, ArgumentKeys<Keys, string>>
 }

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -3,7 +3,6 @@
  *
  * @param {Record<string, unknown>} object - Object to pick from
  * @param {string | string[]} pick - Key or keys to pick from the object
- * @returns {Pick<Obj, Keys & string>} - Object with only the picked keys
  * @example
  *
  * const user = {
@@ -18,17 +17,13 @@
  * // Expected: { username: "john_doe" }
  * pick(user, "username")
  */
-export const pick = <Obj extends Record<string, unknown>, Keys extends keyof Obj | (keyof Obj)[]>(
-    object: Obj,
-    pick: Keys,
-): Pick<Obj, Keys & string> => {
+export const pick = <Obj extends Record<string, unknown>, Keys extends keyof Obj | (keyof Obj)[]>(object: Obj, pick: Keys) => {
     const keys = Array.isArray(pick) ? pick : [pick]
-    const picked = Object.keys(object).reduce(
+    return Object.keys(object).reduce(
         (previous, now) => ({
             ...previous,
             ...(keys.includes(now as Keys) ? { [now]: object[now] } : {}),
         }),
         {},
-    )
-    return picked as Pick<Obj, Keys & string>
+    ) as Pick<Obj, Extract<Keys extends unknown[] ? Keys[number] : Keys, keyof Obj>>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type ArgumentKeys<Keys, U = unknown> = Keys extends U[] ? Keys[number] : Keys

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,5 +1,6 @@
-import { describe, test } from "vitest"
+import { describe, expectTypeOf, test } from "vitest"
 import { deepMerge } from "../src/deep"
+import type { Merge as DeepMerge } from "@halvaradop/ts-utility-types"
 
 interface TestCase {
     description: string
@@ -501,5 +502,24 @@ describe("deepMerge", () => {
         test.concurrent(description, ({ expect }) => {
             expect(deepMerge(source, target, priority)).toEqual(expected)
         })
+    })
+
+    test("checks the return type", () => {
+        const source = {
+            foo: {
+                foofoo: {
+                    barfoo: "barfoo",
+                },
+            },
+        }
+        const target = {
+            foo: {
+                bar: {
+                    foobar: "foobar",
+                },
+            },
+        }
+        expectTypeOf(deepMerge(source, target)).toEqualTypeOf<DeepMerge<typeof source, typeof target>>()
+        expectTypeOf(deepMerge(source, target)).toEqualTypeOf<DeepMerge<typeof target, typeof source, false>>()
     })
 })

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -7,7 +7,7 @@ interface TestCase {
     source: Record<string, unknown>
     target: Record<string, unknown>
     expected: Record<string, unknown>
-    priority: "source" | "target" | "object"
+    priorityObjects: boolean
 }
 
 describe("deepMerge", () => {
@@ -27,7 +27,7 @@ describe("deepMerge", () => {
                 bar: 999,
                 foobar: true,
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Target object has priority over source object",
@@ -41,11 +41,11 @@ describe("deepMerge", () => {
                 foobar: "foobar",
             },
             expected: {
-                foo: "barbar",
+                foo: "bar",
                 bar: 999,
-                foobar: "foobar",
+                foobar: true,
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Source object with nested properties merged with target object",
@@ -67,7 +67,7 @@ describe("deepMerge", () => {
                 },
                 barfoo: "barfoo",
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Target object with nested properties merged with source object",
@@ -89,7 +89,7 @@ describe("deepMerge", () => {
                 },
                 barfoo: "barfoo",
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Source object with deeply nested properties merged with target object",
@@ -117,7 +117,7 @@ describe("deepMerge", () => {
                     },
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Target object with deeply nested properties merged with source object",
@@ -137,15 +137,15 @@ describe("deepMerge", () => {
             },
             expected: {
                 foo: {
-                    bar: {
-                        foobar: "foobar",
-                    },
                     foofoo: {
                         barfoo: "barfoo",
                     },
+                    bar: {
+                        foobar: "foobar",
+                    },
                 },
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Deeply nested source object with priority over target object",
@@ -176,7 +176,7 @@ describe("deepMerge", () => {
                     },
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Deeply nested target object with priority over source object",
@@ -202,12 +202,12 @@ describe("deepMerge", () => {
                 foo: {
                     bar: {
                         baz: {
-                            qux: "corge",
+                            qux: "quux",
                         },
                     },
                 },
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Source object with multiple nested properties merged with target object",
@@ -235,7 +235,7 @@ describe("deepMerge", () => {
                     qux: "quux",
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Target object with multiple nested properties merged with source object",
@@ -263,7 +263,7 @@ describe("deepMerge", () => {
                     qux: "quux",
                 },
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Source object with deeply nested properties merged with target object",
@@ -307,7 +307,7 @@ describe("deepMerge", () => {
                     },
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Source object with multiple deeply nested properties merged with target object",
@@ -359,7 +359,7 @@ describe("deepMerge", () => {
                     },
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Target object with multiple deeply nested properties merged with source object",
@@ -400,18 +400,18 @@ describe("deepMerge", () => {
                     bar: {
                         baz: {
                             qux: {
-                                quux: "fred",
+                                quux: "quuz",
                             },
                         },
                     },
                     corge: {
                         grault: {
-                            garply: "plugh",
+                            garply: "waldo",
                         },
                     },
                 },
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "Merge arrays with source object having priority over target object",
@@ -424,7 +424,7 @@ describe("deepMerge", () => {
             expected: {
                 foobar: [1, 2, 3, { foo: "bar" }],
             },
-            priority: "source",
+            priorityObjects: true,
         },
         {
             description: "Merge arrays with target object having priority over source object",
@@ -435,9 +435,9 @@ describe("deepMerge", () => {
                 foobar: [4, 5, 6, { bar: "foo" }],
             },
             expected: {
-                foobar: [4, 5, 6, { bar: "foo" }],
+                foobar: [1, 2, 3, { foo: "bar" }],
             },
-            priority: "target",
+            priorityObjects: false,
         },
         {
             description: "",
@@ -494,13 +494,13 @@ describe("deepMerge", () => {
                     foofoo: [1, 2, 3],
                 },
             },
-            priority: "source",
+            priorityObjects: true,
         },
     ]
 
-    testCases.forEach(({ description, source, target, priority, expected }) => {
+    testCases.forEach(({ description, source, target, priorityObjects, expected }) => {
         test.concurrent(description, ({ expect }) => {
-            expect(deepMerge(source, target, priority)).toEqual(expected)
+            expect(deepMerge(source, target, priorityObjects)).toEqual(expected)
         })
     })
 

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -1,5 +1,6 @@
-import { describe, test } from "vitest"
+import { describe, expectTypeOf, test } from "vitest"
 import { omit, deepOmit } from "../src/omit"
+import type { DeepOmit } from "@halvaradop/ts-utility-types/objects"
 
 interface TestCase {
     description: string
@@ -121,6 +122,26 @@ describe("omit", () => {
             const actual = omit(input, omitKeys as keyof typeof input, deep)
             expect(actual).toEqual(expected)
         })
+    })
+
+    test("Checks return types of omit", () => {
+        const user = {
+            firstname: "john",
+            lastname: "doe",
+            username: "john_doe",
+            address: {
+                city: "New York",
+                country: "USA",
+            },
+            phone: {
+                home: "1234567890",
+                work: "0987654321",
+            },
+        }
+        expectTypeOf(omit(user, ["address", "phone"])).toEqualTypeOf<Omit<typeof user, "address" | "phone">>()
+        expectTypeOf(omit(user, ["address", "phone", "firstname", "username"])).toEqualTypeOf<
+            Omit<typeof user, "address" | "phone" | "firstname" | "username">
+        >()
     })
 })
 
@@ -302,5 +323,32 @@ describe("deepOmit", () => {
             const actual = deepOmit(input, omit)
             expect(actual).toEqual(expected)
         })
+    })
+
+    test("Checks return types of deepOmit", () => {
+        const user = {
+            username: "john_doe",
+            address: {
+                country: {
+                    name: "USA",
+                    code: "US",
+                    city: {
+                        name: "New York",
+                        code: "NY",
+                    },
+                },
+            },
+            phone: {
+                home: "1234567890",
+                work: "0987654321",
+            },
+        }
+        expectTypeOf(deepOmit(user, ["username", "phone.work"])).toEqualTypeOf<DeepOmit<typeof user, "username" | "phone.work">>()
+        expectTypeOf(deepOmit(user, ["username", "phone.work", "address.country.code"])).toEqualTypeOf<
+            DeepOmit<typeof user, "username" | "phone.work" | "address.country.code">
+        >()
+        expectTypeOf(
+            deepOmit(user, ["username", "phone.work", "address.country.code", "address.country.city.code"]),
+        ).toEqualTypeOf<DeepOmit<typeof user, "username" | "phone.work" | "address.country.code" | "address.country.city.code">>()
     })
 })

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -60,7 +60,7 @@ describe("omit", () => {
                 },
             },
             omit: "phone",
-            deep: true,
+            deep: false,
             expected: {
                 username: "john_doe",
                 address: {

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,4 +1,4 @@
-import { describe, test } from "vitest"
+import { describe, expectTypeOf, test } from "vitest"
 import { pick } from "../src/pick"
 
 describe("pick", () => {
@@ -89,5 +89,22 @@ describe("pick", () => {
         test.concurrent(description, ({ expect }) => {
             expect(pick(input, pickedKeys as keyof typeof input)).toEqual(expected)
         })
+    })
+
+    test("check the return type of pick", () => {
+        const user = {
+            username: "john_doe",
+            address: {
+                city: "New York",
+                country: "USA",
+            },
+            phone: {
+                home: "1234567890",
+                work: "0987654321",
+            },
+        }
+        expectTypeOf(pick(user, "username")).toEqualTypeOf<Pick<typeof user, "username">>()
+        expectTypeOf(pick(user, ["address"])).toEqualTypeOf<Pick<typeof user, "address">>()
+        expectTypeOf(pick(user, ["address", "phone"])).toEqualTypeOf<Pick<typeof user, "address" | "phone">>()
     })
 })


### PR DESCRIPTION
## Description

This pull request addresses incorrect return types in the `omit`, `deepOmit`, and `deepMerge` functions within the library. The issue is partially resolved due to the release of `@halvaradop/ts-utility-types` version 0.19.0, which now provides the `DeepOmit` and `DeepPick` utility types essential for our library. Additionally, new test cases have been added to ensure the functions' return types are accurate.

### Key Changes
- Corrected return types for the `omit`, `deepOmit`, and `deepMerge` functions.
- Integrated `@halvaradop/ts-utility-types` version 0.19.0.
- Added comprehensive test cases to validate return types.

## Checklist

- [ ] Documentation updated (if applicable).
- [x] Code changes do not generate warnings.
- [x] Self-review of the code has been completed.
- [ ] All relevant tests have been added and are passing successfully.

## Notes

- For future updates, additional documentation can be added if required.
