### PR TITLE
feat(core): add `has` method

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -1,0 +1,43 @@
+import { isObject } from "@halvaradop/ts-utility-types/validate"
+
+const internalHas = <Obj extends Record<string, any>>(obj: Obj, targetKey: string, path: string = ""): boolean => {
+    return Object.keys(obj).some((key) => {
+        const currentPath = path ? `${path}.${key}` : key
+        if (currentPath === targetKey) {
+            return true
+        }
+        return isObject(obj[key]) && internalHas(obj[key], targetKey, currentPath)
+    })
+}
+
+/**
+ * Checks if a key exists in an object, including nested objects. For nested objects,
+ * the key should be provided in dot notation.
+ *
+ * @param {Record<string, any>} obj - The object to check for the key.
+ * @param {string} key - The key to check for in the object.
+ * @returns {boolean} - Returns true if the key exists in the object, false otherwise.
+ * @example
+ *
+ * const user = {
+ *   username: "john_doe",
+ *   password: "john123",
+ *   email: "john_doe@gmail.com",
+ *   address: {
+ *     street: "123 Main St",
+ *     city: "New York",
+ *   }
+ * }
+ *
+ * // Expected: true
+ * has(user, "username")
+ *
+ * // Expected: true
+ * has(user, "address.street")
+ *
+ * // Expected: false
+ * has(user, "address.zipcode")
+ */
+export const has = <Obj extends Record<string, any>>(obj: Obj, key: string): boolean => {
+    return internalHas(obj, key)
+}

--- a/test/has.test.ts
+++ b/test/has.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest"
+import { has } from "../src/has"
+
+describe("has", () => {
+    const testCases = [
+        {
+            description: "looking for a property that exists in the first level",
+            input: {
+                foo: "bar",
+                baz: {
+                    qux: "quux",
+                },
+            },
+            search: "foo",
+            expected: true,
+        },
+        {
+            description: "looking for a property that exists in the second level",
+            input: {
+                foo: "bar",
+                baz: {
+                    qux: "quux",
+                },
+            },
+            search: "baz.qux",
+            expected: true,
+        },
+        {
+            description: "looking for a deeply nested property that exists",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                    },
+                },
+            },
+            search: "foo.bar.baz.qux",
+            expected: true,
+        },
+        {
+            description: "looking for a sibling property in a nested object",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                        quux: "corge",
+                    },
+                },
+            },
+            search: "foo.bar.quux",
+            expected: true,
+        },
+    ]
+
+    testCases.forEach(({ description, input, search, expected }) => {
+        test(description, () => {
+            expect(has(input, search)).toBe(expected)
+        })
+    })
+})


### PR DESCRIPTION
## Description

This pull request adds a new method to the library called `has`, which checks if a key exists within an object, including nested properties. This method was introduced in response to issue #17.

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
