### PR TITLE
feat(core): add `get` method

### DIFF
--- a/src/get.ts
+++ b/src/get.ts
@@ -1,0 +1,53 @@
+import { DeepKeys, DeepPick, LiteralUnion } from "@halvaradop/ts-utility-types"
+import { isObject } from "@halvaradop/ts-utility-types/validate"
+
+const internalGet = <Obj extends Record<string, unknown>, Keys extends DeepKeys<Obj>>(
+    object: Obj,
+    keys: Keys,
+    path: string = "",
+): DeepPick<Obj, LiteralUnion<Keys & string>> | undefined => {
+    for (const key in object) {
+        const currentPath = path ? `${path}.${key}` : key
+        if (currentPath === keys) {
+            return object[key] as DeepPick<Obj, LiteralUnion<Keys & string>>
+        } else if (isObject(object[key])) {
+            const deeps = internalGet(object[key] as Record<string, unknown>, keys as string, currentPath)
+            if (deeps) {
+                return deeps as DeepPick<Obj, LiteralUnion<Keys & string>>
+            }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Get a value from an object using a dot-separated path.
+ *
+ * @param {Record<string, unknown>} object - The object to search in.
+ * @param {DeepKeys<Object>} keys - The dot-separated path to the value.
+ * @param {unknown} defaultValue - The default value to return if the key is not found.
+ * @returns {DeepPick<Obj, LiteralUnion<Keys & string>>} The value at the specified path or the default value if not found.
+ * @example
+ *
+ * const obj = {
+ *   foo: {
+ *     bar: {
+ *       fizz: "buzz",
+ *     }
+ *   }
+ * }
+ *
+ * // Expected: "buzz"
+ * const value = get(obj, "foo.bar.fizz")
+ *
+ * // Expected: "default"
+ * const value = get(obj, "foo.bar.baz", "default")
+ *
+ */
+export const get = <Obj extends Record<string, unknown>, Keys extends DeepKeys<Obj>>(
+    object: Obj,
+    keys: Keys,
+    defaultValue?: unknown,
+): DeepPick<Obj, LiteralUnion<Keys & string>> | unknown => {
+    return internalGet(object, keys) ?? defaultValue
+}

--- a/test/get.test.ts
+++ b/test/get.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest"
+import { get } from "../src/get"
+
+describe("get", () => {
+    const testCases = [
+        {
+            description: "looking for a property that exists in the first level",
+            input: {
+                foo: "bar",
+                baz: {
+                    qux: "quux",
+                },
+            },
+            get: "foo",
+            expected: "bar",
+        },
+        {
+            description: "looking for a property that exists in the second level",
+            input: {
+                foo: "bar",
+                baz: {
+                    qux: "quux",
+                },
+            },
+            get: "baz.qux",
+            expected: "quux",
+        },
+        {
+            description: "looking for a deeply nested property that exists",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                    },
+                },
+            },
+            get: "foo.bar.baz.qux",
+            expected: "quux",
+        },
+        {
+            description: "looking for a sibling property in a nested object",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                        quux: "corge",
+                    },
+                },
+            },
+            get: "foo.bar.quux",
+            expected: "corge",
+        },
+        {
+            description: "looking for a property that does not exist in the first level",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                    },
+                },
+            },
+            get: "foo.baz",
+            expected: undefined,
+        },
+        {
+            description: "looking for a property that does not exist and returning a default value",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                    },
+                },
+            },
+            get: "foo.baz",
+            defaultValue: -1,
+            expected: -1,
+        },
+        {
+            description: "looking for a deeply nested property that does not exist and returning a default value",
+            input: {
+                foo: {
+                    bar: {
+                        baz: {
+                            qux: "quux",
+                        },
+                    },
+                },
+            },
+            get: "foo.bar.baz.qz",
+            defaultValue: "default",
+            expected: "default",
+        },
+    ]
+
+    testCases.forEach(({ description, input, get: getKey, expected, defaultValue }) => {
+        test(description, () => {
+            expect(get(input, getKey as any, defaultValue)).toEqual(expected)
+        })
+    })
+})


### PR DESCRIPTION

## Description

This pull request adds a new method called `get` which retrieve a value of a looked for key in an object in any depth. If the key doesn't exist the user can set the third argument called `defaultValue` which overwrite the expected value. This method was introduced to the open issue #11

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
