### PR TITLE
feat(core): add `set` method

### DIFF
--- a/src/set.ts
+++ b/src/set.ts
@@ -1,0 +1,66 @@
+import { DeepKeys } from "@halvaradop/ts-utility-types"
+import { isObject } from "@halvaradop/ts-utility-types/validate"
+import { deepMerge } from "./deep.js"
+
+/**
+ * @internal
+ */
+const internalSet = <Obj extends Record<string, any>>(obj: Obj, key: DeepKeys<Obj> & string, value: any) => {
+    const split = key.split(".")
+    const startKey = split[0]
+    const rightKeys = split.slice(1).join(".")
+    Object.keys(obj).forEach((entryKey) => {
+        if (startKey === entryKey) {
+            if (rightKeys.length === 0) {
+                obj[entryKey as keyof Obj] = value
+            } else {
+                if (isObject(obj[entryKey as keyof Obj])) {
+                    internalSet(obj[entryKey as keyof Obj], rightKeys as any, value)
+                }
+            }
+        }
+    })
+}
+
+/**
+ * Sets a value in an object at a given path.
+ *
+ * @param {Record<string, any>} obj - The object to set the value in.
+ * @param {string} key - The path to set the value at.
+ * @param {any} value - The value to set.
+ * @param {boolean} newCopy - Whether to return a new copy of the object or not. Defaults to false.
+ * @returns The modified object.
+ * @example
+ *
+ * const obj = {
+ *   foo: "bar",
+ *   bar: {
+ *     foofoo: "barfoo",
+ *     barbar: {
+ *       bar: "barbar",
+ *     }
+ *   }
+ * }
+ *
+ * // Expected:
+ * {
+ *   foo: "bar",
+ *   bar: {
+ *     foofoo: "barfoo",
+ *     barbar: {
+ *       bar: "newBar",
+ *     }
+ *   }
+ * }
+ * const newObj = set(obj, "bar.barbar.bar", "newBar", true)
+ *
+ */
+export const set = <Obj extends Record<string, any>>(
+    obj: Obj,
+    key: DeepKeys<Obj> & string,
+    value: any,
+    newCopy: boolean = false,
+) => {
+    internalSet(obj, key, value)
+    return newCopy ? deepMerge(obj, {}) : obj
+}

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest"
+import { set } from "../src/set"
+
+describe("set", () => {
+    const testCases = [
+        {
+            input: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+            key: "foo",
+            value: "newBar",
+            expected: {
+                foo: "newBar",
+                bar: {
+                    foofoo: "barfoo",
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+        },
+        {
+            input: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "barbar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "foobar",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+            key: "fizz.buzz",
+            value: "newBar",
+            expected: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "barbar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "foobar",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "newBar",
+                },
+            },
+        },
+        {
+            input: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "barbar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "foobar",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+            key: "bar.barbar.bar",
+            value: "newBar",
+            expected: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "newBar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "foobar",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+        },
+
+        {
+            input: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "barbar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "foobar",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+            key: "bar.barbar.fizz.buzz",
+            value: "newBuzz",
+            expected: {
+                foo: "bar",
+                bar: {
+                    foofoo: "barfoo",
+                    barbar: {
+                        bar: "barbar",
+                        foo: "bazbar",
+                        fizz: {
+                            buzz: "newBuzz",
+                        },
+                    },
+                },
+                fizz: {
+                    buzz: "foobar",
+                },
+            },
+        },
+    ]
+
+    testCases.forEach(({ input, key, value, expected }) => {
+        test(`set ${key} to ${value}`, () => {
+            const result = set(input, key as any, value)
+            expect(result).toEqual(expected)
+        })
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces a new method to the library called `set`, which enables users to update or assign a value to an object at any depth. This method is especially useful for scenarios where deeply nested object values need to be modified frequently.

This enhancement addresses issue #12 

<!-- Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation
- [x] The changes do not generate any warnings
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
