### PR TITLE
feat(core): add `deepClone` method

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,0 +1,26 @@
+import { isArray, isObject } from "@halvaradop/ts-utility-types/validate"
+import { isSimpleType } from "./utils.js"
+
+export const deepClone = <T extends Record<string, any> | unknown[]>(obj: T, nullish: boolean = true): T => {
+    const clone: any = isArray(obj) ? [] : {}
+    for (const key in obj) {
+        if (isSimpleType(obj[key], nullish)) {
+            clone[key] = obj[key]
+        } else if (isObject(obj[key])) {
+            clone[key] = deepClone(obj[key], nullish)
+        } else if (isArray(obj[key])) {
+            clone[key] = deepClone(obj[key], nullish)
+        }
+    }
+    return clone
+}
+
+/**
+ * Creates a deep copy of an array. It uses the `merge` function to copy objects and arrays.
+ *
+ * @param {unknown[]} source - The source array to copy.
+ * @returns {unknown[]} - The deep copied array.
+ */
+export const deepCopyArray = <Array extends unknown[]>(source: Array, nullish: boolean = true): Array => {
+    return deepClone(source, nullish)
+}

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest"
+import { deepClone } from "../src/clone"
+
+describe("deepClone", () => {
+    const testCases = [
+        {
+            foo: "bar",
+            bar: 42,
+        },
+        {
+            foo: "bar",
+            bar: {
+                baz: 42,
+            },
+        },
+        {
+            foo: "bar",
+            bar: {
+                foobar: {
+                    foofoo: {
+                        barbar: {
+                            baz: 42,
+                        },
+                    },
+                },
+            },
+        },
+        {
+            foo: "bar",
+            bar: {
+                foobar: {
+                    foofoo: {
+                        barbar: {
+                            baz: 42,
+                            bar: undefined,
+                        },
+                        barfoo: null,
+                    },
+                    foobar: undefined,
+                },
+                barbar: null,
+            },
+        },
+        {
+            foo: ["bar", "baz"],
+            bar: {
+                baz: 42,
+            },
+        },
+        {
+            foo: ["bar", "baz"],
+            bar: {
+                foobar: [{ foo: [{ bar: { foobar: ["baz"] } }] }, { bar: { barbar: [{ bar: 12 }] } }],
+            },
+        },
+    ]
+
+    testCases.forEach((testCase) => {
+        test(`deepClone(${JSON.stringify(testCase)})`, () => {
+            const clone = deepClone(testCase)
+            expect(clone).toEqual(testCase)
+        })
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces a new method called `deepClone`, which creates a deep copy of arrays or objects at any depth. This utility ensures that nested structures are fully cloned without preserving references to the original values.

The feature was added in response to issue #18 

Additionally, the existing `deepCopyArray` function was moved from the `deep.ts` file to a new file named `clone.ts` to improve code organization and maintainability.

<!-- Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation
- [x] The changes do not generate any warnings
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
