### PR TITLE
chore(config): implement custom import paths for module resolution

### DIFF
--- a/src/deep.ts
+++ b/src/deep.ts
@@ -1,8 +1,8 @@
 import { isObject, isArray, isNullish } from "@halvaradop/ts-utility-types/validate"
 import { DeepMerge, DeepNonNullish } from "@halvaradop/ts-utility-types/deep"
-import { isPrimitiveOrFunction } from "./utils.js"
-import { deepOmit } from "./omit.js"
-import { deepCloneArray } from "./clone.js"
+import { isPrimitiveOrFunction } from "@/utils.js"
+import { deepOmit } from "@/omit.js"
+import { deepCloneArray } from "@/clone.js"
 
 /**
  * Merges two objects in any depth recursively, by default the source object has priority over

--- a/src/get.ts
+++ b/src/get.ts
@@ -1,6 +1,6 @@
 import { DeepKeys, DeepGet } from "@halvaradop/ts-utility-types"
 import { isObject } from "@halvaradop/ts-utility-types/validate"
-import { getKeyFromPath } from "./utils.js"
+import { getKeyFromPath } from "@/utils.js"
 
 /**
  *  @internal

--- a/src/has.ts
+++ b/src/has.ts
@@ -1,5 +1,5 @@
 import { isObject } from "@halvaradop/ts-utility-types/validate"
-import { getKeyFromPath } from "./utils.js"
+import { getKeyFromPath } from "@/utils.js"
 
 /**
  * Checks if a key exists in an object, including nested objects. For nested objects,

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -1,7 +1,7 @@
 import { isArray, isObject } from "@halvaradop/ts-utility-types/validate"
 import type { DeepKeys, DeepOmit } from "@halvaradop/ts-utility-types"
-import type { ArgumentKeys } from "./types.js"
-import { deepMerge } from "./deep.js"
+import type { ArgumentKeys } from "@/types.js"
+import { deepMerge } from "@/deep.js"
 
 /**
  * Omit properties from an object by key or keys of the first level of the object.

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -1,4 +1,4 @@
-import type { ArgumentKeys } from "./types.js"
+import type { ArgumentKeys } from "@/types.js"
 
 /**
  * Create a new object with only the picked keys.

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,7 +1,7 @@
 import { DeepKeys, DeepSet } from "@halvaradop/ts-utility-types"
 import { isObject } from "@halvaradop/ts-utility-types/validate"
-import { deepMerge } from "./deep.js"
-import { getKeyFromPath } from "./utils.js"
+import { deepMerge } from "@/deep.js"
+import { getKeyFromPath } from "@/utils.js"
 
 /**
  * @internal

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, test } from "vitest"
-import { deepClone, deepCloneArray, deepCloneObject } from "../src/clone"
+import { deepClone, deepCloneArray, deepCloneObject } from "@/clone.js"
 
 describe("deepCloneObject", () => {
     const testCasesWithoutNullish = [

--- a/test/get.test.ts
+++ b/test/get.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, test } from "vitest"
-import { get } from "../src/get"
+import { get } from "@/get.js"
 
 describe("get", () => {
     const testCasesWithoutDefault = [

--- a/test/has.test.ts
+++ b/test/has.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, test } from "vitest"
-import { has } from "../src/has"
+import { has } from "@/has.js"
 
 describe("has", () => {
     const testCases = [

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import type { DeepMerge, DeepNonNullish } from "@halvaradop/ts-utility-types"
-import { deepMerge } from "../src/deep"
-import { mockStore, mockUser } from "./testcases"
+import { deepMerge } from "@/deep.js"
+import { mockStore, mockUser } from "./testcases.js"
 
 interface TestCase {
     description: string

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest"
 import type { DeepOmit } from "@halvaradop/ts-utility-types"
-import { mockUser } from "./testcases"
-import { omit, deepOmit } from "../src/omit"
+import { mockUser } from "./testcases.js"
+import { omit, deepOmit } from "@/omit.js"
 
 interface TestCase {
     description: string

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest"
-import { pick } from "../src/pick"
-import { mockUser } from "./testcases"
+import { pick } from "@/pick.js"
+import { mockUser } from "./testcases.js"
 
 describe("pick", () => {
     const testCases = [

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, test } from "vitest"
-import { set } from "../src/set"
-import { mockUser } from "./testcases"
-import { deepClone } from "../src/clone"
+import { set } from "@/set.js"
+import { mockUser } from "./testcases.js"
+import { deepClone } from "@/clone.js"
 
 describe("set", () => {
     const testCases = [

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { getKeyFromPath, isPrimitiveOrFunction } from "../src/utils"
+import { getKeyFromPath, isPrimitiveOrFunction } from "@/utils.js"
 
 describe("isPrimitiveOrFunction", () => {
     const testCases = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "display": "Node 20",
   "_version": "20.1.0",
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
@@ -22,5 +22,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION

## Description

This pull request implements the custom paths set in the `tsconfig.json` configuration file to add import paths for module resolution across the project. The path created as `"@/*"` which refers to the `src/*`. Additionally was added `test` folder to the scanner of typescript for use the imports withing the test folder

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
